### PR TITLE
Fix OrbitControls import

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,9 +20,9 @@
 <body>
   <div id="hud">Coins: <span id="coinCount">0</span></div>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/examples/js/controls/OrbitControls.js"></script>
-  <script>
+  <script type="module">
+    import * as THREE from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.module.js';
+    import { OrbitControls } from 'https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/examples/jsm/controls/OrbitControls.js';
 // Bob-omb Battlefield demo using Three.js
 // Scene setup
 let scene, camera, renderer, controls, clock;
@@ -47,7 +47,7 @@ function init() {
   renderer.setSize(window.innerWidth, window.innerHeight);
   document.body.appendChild(renderer.domElement);
 
-  controls = new THREE.OrbitControls(camera, renderer.domElement);
+  controls = new OrbitControls(camera, renderer.domElement);
   controls.target.set(0, 5, 0);
   controls.maxPolarAngle = Math.PI / 2.2;
   controls.update();


### PR DESCRIPTION
## Summary
- change to ES module import for three.js
- initialize OrbitControls using module syntax

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688266b7a1a083289223cf856d32d6ce